### PR TITLE
Update offer-signals.service.ts

### DIFF
--- a/src/app/services/offer-signals.service.ts
+++ b/src/app/services/offer-signals.service.ts
@@ -1,26 +1,25 @@
 import {Injectable, signal, WritableSignal} from '@angular/core';
 import {AdditionalOfferType} from "../enums/additional-offer.type.enum";
-
 @Injectable({
   providedIn: 'root'
 })
 export class OfferSignalsService {
-  public insuranceSignal: WritableSignal<number> = signal(null);
-  public abroadSignal: WritableSignal<number> = signal(null);
-  public secondPhoneNumberSignal: WritableSignal<number> = signal(null);
+  insuranceSignal: WritableSignal<number> = signal(null);
+  abroadSignal: WritableSignal<number> = signal(null);
+  secondPhoneNumberSignal: WritableSignal<number> = signal(null);
 
-  public additionalServiceChecked(additionalOfferType: AdditionalOfferType, event: Event): void {
+  additionalServiceChecked(additionalOfferType: AdditionalOfferType, event: Event): void {
     const checkboxEvent: HTMLInputElement = event.target as HTMLInputElement;
 
     switch (additionalOfferType) {
       case AdditionalOfferType.INSURANCE:
-        checkboxEvent.checked ? this.insuranceSignal.set(9) : this.insuranceSignal.set(0);
+        this.insuranceSignal.set(checkboxEvent.checked ? 9 : 0);
         return;
       case AdditionalOfferType.ABROAD:
-        checkboxEvent.checked ? this.abroadSignal.set(19) : this.abroadSignal.set(0);
+        this.abroadSignal.set(checkboxEvent.checked ? 19 : 0);
         return;
       case AdditionalOfferType.SECOND_NUMBER:
-        checkboxEvent.checked ? this.secondPhoneNumberSignal.set(13) : this.secondPhoneNumberSignal.set(0);
+       this.secondPhoneNumberSignal.set(checkboxEvent.checked ? 13 : 0);
         return;
     }
   }


### PR DESCRIPTION
- Domyślnie, jeśli nie określimy modyfikatora dostępu dla pola lub metody, jest ono traktowane jako public. Oznacza to, że nie musimy podawać public

- W przypadku wykorzystania ternary operator zapis może być krótszy:  this.insuranceSignal.set(checkboxEvent.checked ? 9 : 0)

-  Użycie stałej zamiast magicznej liczby sprawia, że kod jest bardziej czytelny i łatwy do zrozumienia